### PR TITLE
[ performance ] Less nesting and no Inf annotations

### DIFF
--- a/src/Main.idr
+++ b/src/Main.idr
@@ -6,21 +6,23 @@ import Data.Fuel
 import System
 import System.File
 
-bytes : Bits32 -> String -> IO (Source FileError ByteString ByteString)
-bytes n s = do
-  Right h <- openFile s Read | Left err => pure (Fail err)
-  pure (bytes n h $> empty)
-
 main : IO ()
-main = do
-  (_ :: fs) <- getArgs | _ => putStrLn "Missing arguments"
-  res <- run
-           (limit 10000000000)
-           (Fan (fromList fs) (bytes 65536) (Pure empty))
-           (writeBytes stdout)
 
-  case res of
-    SinkFull             => putStrLn "sink overflow"
-    (SourceEmpty result) => pure ()
-    (Err error)          => putStrLn "Error: \{show error}"
-    NoMoreFuel           => putStrLn "running on empty"
+-- bytes : Bits32 -> String -> IO (Source FileError ByteString ByteString)
+-- bytes n s = do
+--   Right h <- openFile s Read | Left err => pure (Fail err)
+--   pure (bytes n h $> empty)
+-- 
+-- main : IO ()
+-- main = do
+--   (_ :: fs) <- getArgs | _ => putStrLn "Missing arguments"
+--   res <- run
+--            (limit 10000000000)
+--            (Fan (fromList fs) (bytes 65536) (Pure empty))
+--            (writeBytes stdout)
+-- 
+--   case res of
+--     SinkFull             => putStrLn "sink overflow"
+--     (SourceEmpty result) => pure ()
+--     (Err error)          => putStrLn "Error: \{show error}"
+--     NoMoreFuel           => putStrLn "running on empty"

--- a/src/Stream/Internal.idr
+++ b/src/Stream/Internal.idr
@@ -21,23 +21,20 @@ import Control.WellFounded
 import Data.Fuel
 import Data.Nat
 
-||| A lifte value.
-public export
-data PFM : (f,m : Type -> Type) -> (r : Type) -> Type where
-  P : (val : r)   -> PFM f m r
-  F : (eff : f r) -> PFM f m r
-  M : (act : m r) -> PFM f m r
-
 public export
 data Stream : (f,m : Type -> Type) -> (r : Type) -> Type where
-  Lift : PFM f m r -> Stream f m r
-  Bind :  Stream f m r -> (r -> Stream f m s) -> Stream f m s
+  Bind : Stream f m r -> (r -> Stream f m s) -> Stream f m s
+  P    : r -> Stream f m r
+  F    : f r -> Stream f m r
+  M    : m r -> Stream f m r
 
 ||| Calculates the number of left-nested binds in a `Stream`.
 public export
 depth : Stream f m r -> Nat
-depth (Lift x)   = 0
 depth (Bind x y) = S $ depth x
+depth (P x)      = 0
+depth (F x)      = 0
+depth (M x)      = 0
 
 public export
 Sized (Stream f m r) where
@@ -46,14 +43,22 @@ Sized (Stream f m r) where
 ||| A view on a `Stream` with left-nested binds reassociated.
 public export
 data View : (f,m : Type -> Type) -> (r : Type) -> Type where
-  VLift : PFM f m r -> View f m r
-  VBind : PFM f m r -> (r -> Stream f m s) -> View f m s
+  BindP : r   -> (r -> Stream f m s) -> View f m s
+  BindF : f r -> (r -> Stream f m s) -> View f m s
+  BindM : m r -> (r -> Stream f m s) -> View f m s
+  VP    : r   -> View f m r
+  VF    : f r -> View f m r
+  VM    : m r -> View f m r
 
 view_ : (s : Stream f m r) -> (0 _ : SizeAccessible s) -> View f m r
 view_ (Bind x y) (Access rec) = case x of
-  Lift v   => VBind v y
+  F v      => BindF v y
   Bind z w => view_ (Bind z $ \v => Bind (w v) y) (rec _ reflexive)
-view_ (Lift v) _ = VLift v
+  P v      => BindP v y
+  M v      => BindM v y
+view_ (F v) _ = VF v
+view_ (P v) _ = VP v
+view_ (M v) _ = VM v
 
 export %inline
 toView : (s : Stream f m r) -> View f m r
@@ -61,8 +66,12 @@ toView s = view_ s (sizeAccessible s)
 
 export %inline
 fromView : View f m r -> Stream f m r
-fromView (VLift x)   = Lift x
-fromView (VBind x y) = Bind (Lift x) y
+fromView (BindP x y) = Bind (P x) y
+fromView (BindF x y) = Bind (F x) y
+fromView (BindM x y) = Bind (M x) y
+fromView (VF x)      = F x
+fromView (VP x)      = P x
+fromView (VM x)      = M x
 
 --------------------------------------------------------------------------------
 --          Interfaces
@@ -70,11 +79,11 @@ fromView (VBind x y) = Bind (Lift x) y
 
 export
 Functor (Stream f m) where
-  map f s = Bind s (Lift . P . f)
+  map f s = Bind s (P . f)
 
 export %inline
 Applicative (Stream f m) where
-  pure      = Lift . P
+  pure      = P
   fn <*> fk = Bind fn (\fun => map (fun $ ) fk)
 
 export %inline
@@ -83,7 +92,7 @@ Monad (Stream f m) where
 
 export %inline
 HasIO io => HasIO (Stream f io) where
-  liftIO = Lift . M . liftIO
+  liftIO = M . liftIO
 
 --------------------------------------------------------------------------------
 --          Lifting Values
@@ -91,23 +100,23 @@ HasIO io => HasIO (Stream f io) where
 
 export %inline
 wrap : f (Stream f m r) -> Stream f m r
-wrap v = Bind (Lift $ F v) id
+wrap v = Bind (F v) id
 
 export %inline
 effect : m (Stream f m r) -> Stream f m r
-effect v = Bind (Lift $ M v) id
+effect v = Bind (M v) id
 
 export %inline
 yields : f r -> Stream f m r
-yields = Lift . F
+yields = F
 
 export %inline
 yieldsM : m (f r) -> Stream f m r
-yieldsM v = Bind (Lift $ M v) (Lift . F)
+yieldsM v = Bind (M v) F
 
 export %inline
 lift : m r -> Stream f m r
-lift = Lift . M
+lift = M
 
 --------------------------------------------------------------------------------
 --          Running Streams
@@ -121,28 +130,23 @@ runWith : Fuel -> Stream Empty IO r -> IO (Maybe r)
 runWith fuel s = fromPrim $ go fuel (toView s)
   where go : Fuel -> View Empty IO r -> (1 w : %World) -> IORes (Maybe r)
         go Dry _                w = MkIORes Nothing w
-        go (More x) (VBind y z) w = case y of
-          P val => go x (toView $ z val) w
-          M act =>
-            let MkIORes val w2 = toPrim act w
-             in go x (toView $ z val) w2
-        go (More x) (VLift $ P r) w = MkIORes (Just r) w
-        go (More x) (VLift $ M r)      w =
+        go (More x) (BindM y z) w =
+          let MkIORes val w2 = toPrim y w
+           in go x (toView $ z val) w2
+        go (More x) (BindP y z) w = go x (toView $ z y) w
+
+        go (More x) (VM r) w =
             let MkIORes val w2 = toPrim r w
              in MkIORes (Just val) w2
+        go (More x) (VP r) w = MkIORes (Just r) w
 
 export
 runPure : Fuel -> Stream Empty Empty r -> Maybe r
 runPure fuel s = go fuel (toView s)
   where go : Fuel -> View Empty Empty r -> Maybe r
+        go (More x) (BindP y z) = go x (toView $ z y)
+        go (More x) (VP r)      = Just r
         go Dry _                = Nothing
-        go (More x) (VBind y z) = case y of
-          P val => go x (toView $ z val)
-          M act impossible
-          F eff impossible
-        go (More x) (VLift $ P r) = Just r
-        go (More x) (VLift $ M r) impossible
-        go (More x) (VLift $ F r) impossible
 
 export %inline
 runWith_ : Fuel -> Stream Empty IO r -> IO ()
@@ -159,12 +163,12 @@ run_ = runWith_ forever
 export
 concat : Stream (Stream f m) m r -> Stream f m r
 concat s = case toView s of
-  VBind (P val) y => pure val >>= \v => concat (y v)
-  VBind (F eff) y => eff      >>= \v => concat (y v)
-  VBind (M act) y => lift act >>= \v => concat (y v)
-  VLift (P val)   => pure val
-  VLift (F eff)   => eff
-  VLift (M act)   => lift act
+  BindF eff y => eff      >>= \v => concat (y v)
+  BindP val y => pure val >>= \v => concat (y v)
+  BindM act y => lift act >>= \v => concat (y v)
+  VF eff      => eff
+  VP val      => pure val
+  VM act      => lift act
 
 --------------------------------------------------------------------------------
 --          Mapping Values
@@ -172,21 +176,21 @@ concat s = case toView s of
 
 maps_ : ((0 x : _) -> f x -> g x) -> Stream f m r -> Stream g m r
 maps_ fun fn = case toView fn of
-  VBind (P val) fu => pure val >>= \x => maps_ fun (fu x)
-  VBind (F eff) fu => yields (fun _ eff) >>= \x => maps_ fun (fu x)
-  VBind (M act) fu => lift act >>= \x => maps_ fun (fu x)
-  VLift (P val)    => pure val
-  VLift (F eff)    => yields $ fun _ eff
-  VLift (M act)    => lift act
+  BindF eff fu => yields (fun _ eff) >>= \x => maps_ fun (fu x)
+  BindP val fu => pure val >>= \x => maps_ fun (fu x)
+  BindM act fu => lift act >>= \x => maps_ fun (fu x)
+  VP val       => pure val
+  VF eff       => yields $ fun _ eff
+  VM act       => lift act
 
 mapsM_ : ((0 x : _) -> f x -> m (g x)) -> Stream f m r -> Stream g m r
 mapsM_ fun fn = case toView fn of
-  VBind (P val) fu => pure val >>= \x => mapsM_ fun (fu x)
-  VBind (F eff) fu => lift (fun _ eff) >>= yields >>= \v => mapsM_ fun (fu v)
-  VBind (M act) fu => lift act >>= \x => mapsM_ fun (fu x)
-  VLift (P val)    => pure val
-  VLift (F eff)    => Bind (lift $ fun _ eff) yields
-  VLift (M act)    => lift act
+  BindF eff fu => lift (fun _ eff) >>= yields >>= \v => mapsM_ fun (fu v)
+  BindP val fu => pure val >>= \x => mapsM_ fun (fu x)
+  BindM act fu => lift act >>= \x => mapsM_ fun (fu x)
+  VP val       => pure val
+  VF eff       => Bind (lift $ fun _ eff) yields
+  VM act       => lift act
 
 export %inline
 maps : (forall x . f x -> g x) -> Stream f m r -> Stream g m r
@@ -224,10 +228,12 @@ export
 splitsAt : Nat -> Stream f m r -> Stream f m (Stream f m r)
 splitsAt 0     x = pure x
 splitsAt (S k) x = case toView x of
-  VLift y         => pure (Lift y)
-  VBind (P val) z => Bind (pure val)   (\v => splitsAt (S k) (z v))
-  VBind (F eff) z => Bind (yields eff) (\v => splitsAt k (z v))
-  VBind (M act) z => Bind (lift act)   (\v => splitsAt (S k) (z v))
+  BindF eff z => Bind (yields eff) (\v => splitsAt k (z v))
+  BindP val z => Bind (pure val)   (\v => splitsAt (S k) (z v))
+  BindM act z => Bind (lift act)   (\v => splitsAt (S k) (z v))
+  VF v        => pure (F v)
+  VP v        => pure (P v)
+  VM v        => pure (M v)
 
 export
 take : Nat -> Stream f m r -> Stream f m ()

--- a/src/Stream/Util.idr
+++ b/src/Stream/Util.idr
@@ -23,31 +23,31 @@ yield = yields . MkOf
 export
 list : List a -> Stream (Of a) m ()
 list []        = pure ()
-list (x :: xs) = yield x >> list xs
+list (x :: xs) = yield x >>= \_ => list xs
 
 export
 stream : Stream a -> Stream (Of a) m Void
-stream (x :: y) = yield x >> stream y
+stream (x :: y) = yield x >>= \_ => stream y
 
 export
 colist : Colist a -> Stream (Of a) m ()
 colist []       = pure ()
-colist (x :: y) = yield x >> colist y
+colist (x :: y) = yield x >>= \_ => colist y
 
 ||| Generates the sequence (ini, f ini, f $ f ini, ...)
 export
 iterate : (fun : a -> a) -> (ini : a) -> Stream (Of a) m Void
-iterate f ini = yield ini >> iterate f (f ini)
+iterate f ini = yield ini >>= \_ => iterate f (f ini)
 
 export
 generate : (s -> (s,a)) -> s -> Stream (Of a) m Void
-generate f ini = let (vs,va) = f ini in yield va >> generate f vs
+generate f ini = let (vs,va) = f ini in yield va >>= \_ => generate f vs
 
 export
 tillRight : m (Either a r) -> Stream (Of a) m r
 tillRight x = lift x >>= next
   where next : Either a r -> Stream (Of a) m r
-        next (Left v)  = yield v >> tillRight x
+        next (Left v)  = yield v >>= \_ => tillRight x
         next (Right r) = pure r
 
 --------------------------------------------------------------------------------
@@ -57,12 +57,12 @@ tillRight x = lift x >>= next
 export
 mapM_ : (a -> m x) -> Stream (Of a) m r -> Stream Empty m r
 mapM_ f y = case toView y of
-  VBind (P val)      (Delay w) => pure val >>= \v => mapM_ f (w v)
-  VBind (F $ MkOf v) (Delay w) => lift (f v) >> mapM_ f (w v)
-  VBind (M act)      (Delay w) => lift act >>= \v => mapM_ f (w v)
-  VLift (P val)                => pure val
-  VLift (F $ MkOf v)           => lift (f v) $> v
-  VLift (M act)                => lift act
+  VBind (P val)      w => pure val >>= \v => mapM_ f (w v)
+  VBind (F $ MkOf v) w => lift (f v) >>= \_ => mapM_ f (w v)
+  VBind (M act)      w => lift act >>= \v => mapM_ f (w v)
+  VLift (P val)        => pure val
+  VLift (F $ MkOf v)   => lift (f v) $> v
+  VLift (M act)        => lift act
 
 export %inline
 effects : Applicative m => Stream (Of a) m r -> Stream Empty m r
@@ -79,12 +79,12 @@ fold :  (x -> a -> x)
      -> Stream (Of a) m r
      -> Stream Empty m (b,r)
 fold step ini done x = case toView x of
-  VBind (P val)      (Delay z) => pure val >>= \v => fold step ini done (z v)
-  VBind (F $ MkOf v) (Delay z) => pure () >> fold step (step ini v) done (z v)
-  VBind (M act)      (Delay z) => lift act >>= \v => fold step ini done (z v)
-  VLift (P val)                => pure (done ini, val)
-  VLift (F $ MkOf v)           => pure (done $ step ini v, v)
-  VLift (M act)                => (done ini,) <$> lift act
+  VBind (P val)      z => pure val >>= \v => fold step ini done (z v)
+  VBind (F $ MkOf v) z => pure () >> fold step (step ini v) done (z v)
+  VBind (M act)      z => lift act >>= \v => fold step ini done (z v)
+  VLift (P val)        => pure (done ini, val)
+  VLift (F $ MkOf v)   => pure (done $ step ini v, v)
+  VLift (M act)        => (done ini,) <$> lift act
 
 export %inline
 foldMap : Monoid mo => (a -> mo) -> Stream (Of a) m r -> Stream Empty m (mo,r)
@@ -141,12 +141,12 @@ foldM :  (x -> a -> m x)
       -> Stream (Of a) m r
       -> Stream Empty m (b,r)
 foldM step ini done x = case toView x of
-  VBind (F $ MkOf v) (Delay z) => do
+  VBind (F $ MkOf v) z => do
     vx <- lift ini
     foldM step (step vx v) done (z v)
 
-  VBind (P val)      (Delay z) => pure val >>= \v => foldM step ini done (z v)
-  VBind (M act)      (Delay z) => lift act >>= \v => foldM step ini done (z v)
+  VBind (P val)      z => pure val >>= \v => foldM step ini done (z v)
+  VBind (M act)      z => lift act >>= \v => foldM step ini done (z v)
 
   VLift (P val)        => do
     vx <- lift ini
@@ -172,12 +172,12 @@ foldM step ini done x = case toView x of
 export
 for : Stream (Of a) m r -> (a -> Stream f m x) -> Stream f m r
 for str fun = case toView str of
-  VBind (P val)       (Delay z) => pure val >>= \v => for (z v) fun
-  VBind (F (MkOf va)) (Delay z) => fun va >> for (z va) fun
-  VBind (M act)       (Delay z) => lift act >>= \v => for (z v) fun
-  VLift (P val)                 => pure val
-  VLift (F (MkOf va))           => fun va $> va
-  VLift (M act)                 => lift act
+  VBind (P val)       z => pure val >>= \v => for (z v) fun
+  VBind (F (MkOf va)) z => fun va   >>= \_ => for (z va) fun
+  VBind (M act)       z => lift act >>= \v => for (z v) fun
+  VLift (P val)         => pure val
+  VLift (F (MkOf va))   => fun va $> va
+  VLift (M act)         => lift act
 
 export
 mapVals : (a -> b) -> Stream (Of a) m r -> Stream (Of b) m r
@@ -198,30 +198,30 @@ subst fun str = for str (yields . fun)
 export
 filter : (a -> Bool) -> Stream (Of a) m r -> Stream (Of a) m r
 filter p x = case toView x of
-  VBind (F $ MkOf val) (Delay z) =>
+  VBind (F $ MkOf val) z =>
     if p val
        then yield val >>= \v => filter p (z v)
        else pure ()   >>   filter p (z val)
-  VBind (P val) (Delay z) => pure val >>= \v => filter p (z v)
-  VBind (M act) (Delay z) => lift act >>= \v => filter p (z v)
-  VLift (P val)           => pure val
-  VLift (F $ MkOf v)      => if p v then yield v else pure v
-  VLift (M act)           => lift act
+  VBind (P val) z    => pure val >>= \v => filter p (z v)
+  VBind (M act) z    => lift act >>= \v => filter p (z v)
+  VLift (P val)      => pure val
+  VLift (F $ MkOf v) => if p v then yield v else pure v
+  VLift (M act)      => lift act
 
 export
 span :  (a -> Bool)
      -> Stream (Of a) m r 
      -> Stream (Of a) m (Stream (Of a) m r)
 span p x = case toView x of
-  VBind (F $ MkOf val) (Delay z) =>
+  VBind (F $ MkOf val) z =>
     if p val
        then pure ()   >> pure (z val)
        else yield val >>= \v => span p (z v)
-  VBind (P val) (Delay z) => pure val >>= \v => span p (z v)
-  VBind (M act) (Delay z) => lift act >>= \v => span p (z v)
-  VLift (P val)           => pure (pure val)
-  VLift (F $ MkOf v)      => pure $ if p v then yield v else pure v
-  VLift (M act)           => pure $ lift act
+  VBind (P val) z    => pure val >>= \v => span p (z v)
+  VBind (M act) z    => lift act >>= \v => span p (z v)
+  VLift (P val)      => pure (pure val)
+  VLift (F $ MkOf v) => pure $ if p v then yield v else pure v
+  VLift (M act)      => pure $ lift act
 
 export
 takeWhile : (a -> Bool) -> Stream (Of a) m r -> Stream (Of a) m ()


### PR DESCRIPTION
This leads to a significant speed up. Especially wrapping the bind functions in `Inf` led to a slow-down (and a memory leak on the JS backends). Unfortunately, we loose some guarantees from the totality checker for removing `Inf`, so I'll have to think about how to proceed here.